### PR TITLE
Adds time-of-flight sensor support (VL53l0X)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -17,3 +17,6 @@
 	path = cores
 	url = https://github.com/mitchgu/cores
 	branch = more-usb-buffers
+[submodule "libraries/vl53l0x-arduino"]
+	path = libraries/vl53l0x-arduino
+	url = git@github.com:gkanwar/vl53l0x-arduino.git

--- a/Makefile_example
+++ b/Makefile_example
@@ -17,7 +17,7 @@ COREPATH = cores/teensy3
 # path location for Arduino libraries
 LIBRARYPATH = libraries
 
-LIBRARIES = $(LIBRARYPATH)/Wire $(LIBRARYPATH)/Encoder $(LIBRARYPATH)/SPI $(LIBRARYPATH)/Servo $(LIBRARYPATH)/Adafruit_TCS34725
+LIBRARIES = $(LIBRARYPATH)/Wire $(LIBRARYPATH)/Encoder $(LIBRARYPATH)/SPI $(LIBRARYPATH)/Servo $(LIBRARYPATH)/Adafruit_TCS34725 $(LIBRARYPATH)/vl53l0x-arduino
 
 #************************************************************************
 # Location of Teensyduino utilities, Toolchain, and Arduino Libraries.

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Supported Devices
 - [x] Short-range IR Distance Sensor (just an analog input)
 - [x] Ultra-short range IR Distance Sensor (just a digital input)
 - [x] Color Sensor (I2C)
+- [x] Pololu VL53L0X time-of-flight distance sensor (I2C)
 
 Dependencies
 ------------

--- a/src/DeviceList.cpp
+++ b/src/DeviceList.cpp
@@ -114,8 +114,8 @@ std::vector<uint8_t> DeviceList::add(std::vector<uint8_t>& request) {
             } else { return {REQUEST_LENGTH_INVALID_CODE}; };
             break;
         case TOF_CODE:
-            if (request.size() == 2) {
-                d = new TimeOfFlight();
+            if (request.size() == 4) {
+                d = new TimeOfFlight(request[2], request[3]);
             } else { return {REQUEST_LENGTH_INVALID_CODE}; };
             break;
         default:

--- a/src/DeviceList.cpp
+++ b/src/DeviceList.cpp
@@ -15,6 +15,7 @@
 #include "Gyro.h"
 #include "Color.h"
 #include "Servo.h"
+#include "TimeOfFlight.h"
 
 namespace tamproxy {
 
@@ -107,9 +108,14 @@ std::vector<uint8_t> DeviceList::add(std::vector<uint8_t>& request) {
                 d = new Color(request[2], request[3]);
             } else { return {REQUEST_LENGTH_INVALID_CODE}; };
             break;
-	    case SERVO_CODE:
-		    if (request.size() == 3) {
+        case SERVO_CODE:
+            if (request.size() == 3) {
                 d = new Servo(request[2]);
+            } else { return {REQUEST_LENGTH_INVALID_CODE}; };
+            break;
+        case TOF_CODE:
+            if (request.size() == 2) {
+                d = new TimeOfFlight();
             } else { return {REQUEST_LENGTH_INVALID_CODE}; };
             break;
         default:

--- a/src/TimeOfFlight.cpp
+++ b/src/TimeOfFlight.cpp
@@ -1,16 +1,24 @@
 #include "TimeOfFlight.h"
 #include <cstdint>
 #include "VL53L0X.h"
+#include <Wire.h>
 #include "config.h"
+
+#define ADDRESS_DEFAULT 0b0101001
 
 namespace tamproxy {
 
-TimeOfFlight::TimeOfFlight() {
+// xshutPin specifies the digital pin connected to the xshut control,
+// id is a unique identifier 0-15 so that the ToF sensors don't walk
+// over each other.
+TimeOfFlight::TimeOfFlight(uint8_t xshutPin, uint8_t id) {
   init = false;
+  Wire.begin(); // Ensure I2C is set up
   sensor = new VL53L0X();
-  init = sensor->init(true /*use 2V8 mode*/);
-  sensor->setTimeout(500);
-  sensor->startContinuous();
+  _xshutPin = xshutPin;
+  _address = (ADDRESS_DEFAULT & 0xf0) | id;
+  pinMode(xshutPin, OUTPUT);
+  digitalWrite(xshutPin, 0);
 }
 
 TimeOfFlight::~TimeOfFlight() {
@@ -20,17 +28,26 @@ TimeOfFlight::~TimeOfFlight() {
 std::vector<uint8_t> TimeOfFlight::handleRequest(std::vector<uint8_t> &request) {
   if (request.size() != 1) {
     return {REQUEST_LENGTH_INVALID_CODE};
-  } else if (request[0] != TOF_READ_CODE) {
-    return {REQUEST_BODY_INVALID_CODE};
-  } else {
+  } else if (request[0] == TOF_ENABLE_CODE) {
+    digitalWrite(_xshutPin, 1); // re-enable the sensor
+    delay(100);
+    sensor->setAddress(_address);
+    bool isinit = sensor->init(false);
+    sensor->setTimeout(500);
+    sensor->startContinuous();
+    init = isinit;
+    return {_address};
+  } else if (request[0] == TOF_READ_CODE) {
     if (init) {
-      uint16_t range = 100;
+      uint16_t range = 0;
       range = sensor->readRangeContinuousMillimeters();
       return {static_cast<uint8_t>(range>>8), static_cast<uint8_t>(range)};
     }
     else {
       return {0xff, 0xff};
     }
+  } else {
+    return {REQUEST_BODY_INVALID_CODE};
   }
 }
 

--- a/src/TimeOfFlight.cpp
+++ b/src/TimeOfFlight.cpp
@@ -1,0 +1,37 @@
+#include "TimeOfFlight.h"
+#include <cstdint>
+#include "VL53L0X.h"
+#include "config.h"
+
+namespace tamproxy {
+
+TimeOfFlight::TimeOfFlight() {
+  init = false;
+  sensor = new VL53L0X();
+  init = sensor->init(true /*use 2V8 mode*/);
+  sensor->setTimeout(500);
+  sensor->startContinuous();
+}
+
+TimeOfFlight::~TimeOfFlight() {
+  delete sensor;
+}
+
+std::vector<uint8_t> TimeOfFlight::handleRequest(std::vector<uint8_t> &request) {
+  if (request.size() != 1) {
+    return {REQUEST_LENGTH_INVALID_CODE};
+  } else if (request[0] != TOF_READ_CODE) {
+    return {REQUEST_BODY_INVALID_CODE};
+  } else {
+    if (init) {
+      uint16_t range = 100;
+      range = sensor->readRangeContinuousMillimeters();
+      return {static_cast<uint8_t>(range>>8), static_cast<uint8_t>(range)};
+    }
+    else {
+      return {0xff, 0xff};
+    }
+  }
+}
+
+}

--- a/src/TimeOfFlight.h
+++ b/src/TimeOfFlight.h
@@ -11,9 +11,11 @@ namespace tamproxy {
 class TimeOfFlight : public Device {
 private:
   VL53L0X *sensor;
+  uint8_t _xshutPin;
+  uint8_t _address;
   bool init;
 public:
-  TimeOfFlight();
+  TimeOfFlight(uint8_t xshutPin, uint8_t id);
   ~TimeOfFlight();
   std::vector<uint8_t> handleRequest(std::vector<uint8_t> &request);
 };

--- a/src/TimeOfFlight.h
+++ b/src/TimeOfFlight.h
@@ -1,0 +1,23 @@
+#ifndef TIME_OF_FLIGHT_H
+#define TIME_OF_FLIGHT_H
+
+#include <cstdint>
+#include <vector>
+#include "Device.h"
+#include "VL53L0X.h"
+
+namespace tamproxy {
+
+class TimeOfFlight : public Device {
+private:
+  VL53L0X *sensor;
+  bool init;
+public:
+  TimeOfFlight();
+  ~TimeOfFlight();
+  std::vector<uint8_t> handleRequest(std::vector<uint8_t> &request);
+};
+  
+}
+
+#endif

--- a/src/config_example_teensy35.h
+++ b/src/config_example_teensy35.h
@@ -48,6 +48,8 @@
 #define SERVO_CODE 'S'
 #define SERVO_WRITE_CODE 'W'
 #define STEPPER_CODE 's'
+#define TOF_CODE 'T'
+#define TOF_READ_CODE 'R'
 #define ULTRASONIC_CODE 'U'
 
 // PACKETS

--- a/src/config_example_teensy35.h
+++ b/src/config_example_teensy35.h
@@ -49,6 +49,7 @@
 #define SERVO_WRITE_CODE 'W'
 #define STEPPER_CODE 's'
 #define TOF_CODE 'T'
+#define TOF_ENABLE_CODE 'E'
 #define TOF_READ_CODE 'R'
 #define ULTRASONIC_CODE 'U'
 


### PR DESCRIPTION
Supports two messages:
* Enable
* Read

Enable is necessary to support multiple ToF sensors, since they must be brought online one at a time and set to new I2C addresses.