### PR TITLE
Removes blocking ToF code to enable high throughput

### DIFF
--- a/src/Device.h
+++ b/src/Device.h
@@ -9,6 +9,7 @@ namespace tamproxy {
 class Device {
 public:
     virtual std::vector<uint8_t> handleRequest(std::vector<uint8_t> &request) = 0;
+    virtual void doUpkeep() {};
     virtual ~Device() {};
 };
 

--- a/src/DeviceList.cpp
+++ b/src/DeviceList.cpp
@@ -44,6 +44,13 @@ std::vector<uint8_t> DeviceList::handleRequest(std::vector<uint8_t> &request) {
     }
 }
 
+// Do any continuous upkeep
+void DeviceList::doUpkeep() {
+  for (unsigned idx = 0; idx < _devices.size(); ++idx) {
+    _devices[idx]->doUpkeep();
+  }
+}
+
 // Gets a device pointer at a certain index of the list.
 Device* DeviceList::get(uint8_t idx) {
     if (idx < _devices.size()) {

--- a/src/DeviceList.h
+++ b/src/DeviceList.h
@@ -17,6 +17,7 @@ private:
 public:
     std::vector<uint8_t> handleRequest(std::vector<uint8_t> &request);
     Device* get(uint8_t idx);
+    void doUpkeep();
 };
 
 }

--- a/src/TimeOfFlight.h
+++ b/src/TimeOfFlight.h
@@ -13,11 +13,14 @@ private:
   VL53L0X *sensor;
   uint8_t _xshutPin;
   uint8_t _address;
+  uint16_t _upkeepTimer;
+  uint16_t _range;
   bool init;
 public:
   TimeOfFlight(uint8_t xshutPin, uint8_t id);
   ~TimeOfFlight();
   std::vector<uint8_t> handleRequest(std::vector<uint8_t> &request);
+  void doUpkeep();
 };
   
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -53,6 +53,8 @@ void loop() {
         // Send a response packet
         pc->transmit(response);
     }
+    // Do any upkeep actions
+    dl->doUpkeep();
 }
 
 int main(void)


### PR DESCRIPTION
This updates to a version of the ToF library which adds readRangeContinuousNoBlockMillimeters, which allows polling without blocking for a continuous read. It also adds a doUpkeep loop separately in the firmware to ensure a frequent polling. Not strictly necessary here, but I think it generally makes sense to have this structure in place so that the Firmware can do upkeep independently of the pyHost needing to spam requests.